### PR TITLE
Ensure driftwatch package installs for CLI usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "driftwatch"
 version = "0.1.0"
@@ -12,6 +16,9 @@ dependencies = [
 
 [dependency-groups]
 dev = ["pytest>=8.0.0"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/uv.lock
+++ b/uv.lock
@@ -212,7 +212,7 @@ wheels = [
 [[package]]
 name = "driftwatch"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },


### PR DESCRIPTION
## Summary
- configure setuptools build backend and package discovery
- mark the project as an editable dependency so `uv sync` installs it

## Testing
- `uv run python -m driftwatch.cli --help`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3ea93e340832b891b44be404bf081