### PR TITLE
Validate OPENAI_BASE_URL

### DIFF
--- a/src/driftwatch/llm.py
+++ b/src/driftwatch/llm.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import time
 from json import JSONDecodeError
+from urllib.parse import urlparse
 
 import httpx
 from openai import APIConnectionError, OpenAI
@@ -42,6 +43,11 @@ def chat_completion(
     client_kwargs = {"api_key": os.environ["OPENAI_API_KEY"]}
     base_url = os.getenv("OPENAI_BASE_URL")
     if base_url:
+        parsed = urlparse(base_url)
+        if not parsed.scheme or not parsed.netloc:
+            raise RuntimeError(
+                f"Invalid OPENAI_BASE_URL: {base_url!r}. Include scheme, e.g. 'https://api.openai.com/v1'."
+            )
         client_kwargs["base_url"] = base_url
     client = OpenAI(**client_kwargs)
     target_model = model or MODEL_NAME

--- a/tests/test_llm_unit.py
+++ b/tests/test_llm_unit.py
@@ -58,6 +58,15 @@ def test_chat_completion_parses_response(monkeypatch) -> None:
     assert "response" in result
 
 
+def test_chat_completion_rejects_invalid_base_url(monkeypatch) -> None:
+    """chat_completion raises when OPENAI_BASE_URL lacks a scheme."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "example.com")
+    with pytest.raises(RuntimeError, match="Invalid OPENAI_BASE_URL"):
+        chat_completion("hi", model="openai/gpt-5-nano", max_tokens=1024)
+
+
 def test_chat_completion_missing_choices_retries(monkeypatch) -> None:
     """chat_completion retries when no choices are returned."""
 


### PR DESCRIPTION
## Summary
- validate `OPENAI_BASE_URL` to require a URL scheme and raise a helpful error when misconfigured
- test `chat_completion` rejects malformed base URLs

## Testing
- `uv run pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68c4b20ffd18832bb642ab61c649b6e8