### PR TITLE
feat: allow configuring temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ uv sync --dev
 
 Run a specific test problem from either the GSM8K or ARC-Challenge benchmarks
 against one or more models. Select the dataset with ``--dataset`` (defaults to
-``gsm8k``). The results are written as a JSONL file in the provided output
+``gsm8k``). Control sampling diversity with ``--temperature`` (defaults to
+``0.7``). The results are written as a JSONL file in the provided output
 directory. The file name is the timestamp at the start of the run.
 
 ```bash
-uv run python -m driftwatch.cli --dataset arc-challenge --index 5 --models openai/gpt-5-nano other/model --threads 2 --output-dir results/
+uv run python -m driftwatch.cli --dataset arc-challenge --index 5 --models openai/gpt-5-nano other/model --threads 2 --temperature 0.7 --output-dir results/
 ```
 
 Each line contains the prompt, raw OpenAI response object, token usage, latency,

--- a/src/driftwatch/cli.py
+++ b/src/driftwatch/cli.py
@@ -46,7 +46,12 @@ def _completion_to_dict(obj: object) -> dict:
 
 
 def run(
-    dataset: str, index: int, models: Iterable[str], output_dir: Path, threads: int = 1
+    dataset: str,
+    index: int,
+    models: Iterable[str],
+    output_dir: Path,
+    threads: int = 1,
+    temperature: float = 0.7,
 ) -> Path:
     """Run the ``dataset`` problem at ``index`` against each ``models``.
 
@@ -71,7 +76,7 @@ def run(
 
     def _evaluate(model: str) -> dict:
         call_start = time.perf_counter()
-        result = chat_completion(prompt, model=model)
+        result = chat_completion(prompt, model=model, temperature=temperature)
         duration_ms = (time.perf_counter() - call_start) * 1000
         usage = result.get("usage") or {}
         predicted = extract_answer(result.get("message", ""))
@@ -121,8 +126,21 @@ def main(argv: Sequence[str] | None = None) -> None:
         default=1,
         help="Number of concurrent threads to use",
     )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.7,
+        help="Sampling temperature for LLM calls",
+    )
     args = parser.parse_args(argv)
-    run(args.dataset, args.index, args.models, args.output_dir, threads=args.threads)
+    run(
+        args.dataset,
+        args.index,
+        args.models,
+        args.output_dir,
+        threads=args.threads,
+        temperature=args.temperature,
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/src/driftwatch/llm.py
+++ b/src/driftwatch/llm.py
@@ -31,12 +31,14 @@ def chat_completion(
     prompt: str,
     model: str | None = None,
     max_tokens: int = 10_240,
+    temperature: float = 0.7,
 ) -> dict:
     """Return the assistant message and token usage details.
 
     The returned dictionary contains the assistant ``message`` along with ``usage``
     statistics (prompt, cache, reasoning and completion tokens) and ``cost`` for
-    each token type when pricing information is available for ``model``.
+    each token type when pricing information is available for ``model``. The
+    ``temperature`` controls sampling diversity and defaults to ``0.7``.
     """
     _ensure_env()
     client_kwargs = {"api_key": os.environ["OPENAI_API_KEY"]}
@@ -59,6 +61,7 @@ def chat_completion(
                 model=target_model,
                 messages=[{"role": "user", "content": prompt}],
                 max_tokens=max_tokens,
+                temperature=temperature,
                 extra_body={"max_output_tokens": max_tokens},
                 extra_headers={
                     "HTTP-Referer": "https://github.com/aplassard/driftwatch",

--- a/tests/test_arc_eval.py
+++ b/tests/test_arc_eval.py
@@ -5,7 +5,12 @@ from driftwatch import evaluate
 def test_juan_lakeisha_ramp(monkeypatch):
     prompts = {}
 
-    def fake_chat_completion(prompt: str, model: str | None = None, max_tokens: int = 10240):
+    def fake_chat_completion(
+        prompt: str,
+        model: str | None = None,
+        max_tokens: int = 10240,
+        temperature: float = 0.7,
+    ):
         prompts["prompt"] = prompt
         return {
             "message": (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,10 @@ def test_run_writes_jsonl(tmp_path: Path) -> None:
         },
     }
 
-    def fake_chat(prompt: str, model: str) -> dict:
+    temps = {}
+
+    def fake_chat(prompt: str, model: str, temperature: float = 0.7) -> dict:
+        temps[model] = temperature
         return fake_responses[model]
 
     with patch.dict("driftwatch.cli._DATASETS", {"dummy": lambda: [problem]}):
@@ -43,4 +46,5 @@ def test_run_writes_jsonl(tmp_path: Path) -> None:
     assert rec_a["reasoning_tokens"] == 3
     assert rec_a["completion_tokens"] == 2
     assert rec_a["latency_ms"] == 50
+    assert temps == {"model-a": 0.7, "model-b": 0.7}
 

--- a/tests/test_gsm8k_eval.py
+++ b/tests/test_gsm8k_eval.py
@@ -5,7 +5,12 @@ from driftwatch import evaluate
 def test_natalia_clips(monkeypatch):
     prompts = {}
 
-    def fake_chat_completion(prompt: str, model: str | None = None, max_tokens: int = 10240):
+    def fake_chat_completion(
+        prompt: str,
+        model: str | None = None,
+        max_tokens: int = 10240,
+        temperature: float = 0.7,
+    ):
         prompts["prompt"] = prompt
         return {
             "message": (


### PR DESCRIPTION
## Summary
- expose `--temperature` on the CLI and thread it through to evaluations
- allow `chat_completion` to accept temperature for API calls
- document temperature usage in README

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4b324f984832bbf32cddaf36d6a7b