### PR TITLE
Make progressive ARC evaluation resumable

### DIFF
--- a/tests/test_progressive_arc.py
+++ b/tests/test_progressive_arc.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+from driftwatch.data import Problem
+
+
+def load_progressive_arc() -> object:
+    path = Path(__file__).resolve().parents[1] / "scripts" / "progressive_arc.py"
+    spec = importlib.util.spec_from_file_location("progressive_arc", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_run_model_resumes(tmp_path, monkeypatch):
+    progressive_arc = load_progressive_arc()
+    problems = [(0, Problem("Q1", "A")), (1, Problem("Q2", "B"))]
+    calls = []
+
+    def fake_evaluate(problem, model=None, temperature=0.0):
+        calls.append(problem.question)
+        return {"correct": True, "expected": problem.answer, "response": problem.answer}
+
+    monkeypatch.setattr(progressive_arc, "evaluate", fake_evaluate)
+
+    summary = progressive_arc._run_model("model", problems, tmp_path, threads=1, runs=1)
+    assert len(summary) == 2
+    assert len(calls) == 2
+
+    calls.clear()
+    summary = progressive_arc._run_model("model", problems, tmp_path, threads=1, runs=1)
+    assert len(summary) == 2
+    assert len(calls) == 0
+
+    summary_path = tmp_path / "model" / "summary.jsonl"
+    lines = summary_path.read_text().strip().splitlines()
+    assert len(lines) == 2


### PR DESCRIPTION
## Summary
- allow `progressive_arc.py` to skip problems that already have results and append new runs/summary records incrementally
- add regression test to ensure `_run_model` resumes instead of re-evaluating completed problems

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4be1dcb38832bb19555f4cb4e2d3e